### PR TITLE
feat: Add GET /me route to fetch authenticated user details

### DIFF
--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -3,6 +3,7 @@ import {
   loginUser,
   refreshToken,
   logoutUser,
+  getUserDetails,
 } from '../controllers/authController';
 import { authenticate } from './../middlewares/authMiddleware';
 
@@ -10,6 +11,7 @@ const router = Router();
 
 router.post('/login', loginUser);
 router.post('/refresh', refreshToken);
+router.get('/me', authenticate, getUserDetails);
 router.post('/logout', authenticate, logoutUser);
 
 export default router;

--- a/src/swagger/paths/auth.ts
+++ b/src/swagger/paths/auth.ts
@@ -45,6 +45,46 @@ export const authPaths: OpenAPIV3.PathsObject = {
       },
     },
   },
+  '/api/auth/me': {
+    get: {
+      tags: ['Authentication'],
+      summary: 'Get current user details',
+      description: 'Retrieves the profile information of the currently authenticated user (admin, agent, or student).',
+      security: [{ BearerAuth: [] }],
+      responses: {
+        '200': {
+          description: 'Successfully retrieved user profile.',
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  { $ref: '#/components/schemas/AdminProfileResponse' },
+                  { $ref: '#/components/schemas/AgentProfileResponse' },
+                  { $ref: '#/components/schemas/UserResponse' },
+                ],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Unauthorized. Invalid or missing token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'User not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
   '/api/auth/logout': {
     post: {
       tags: ['Authentication'],


### PR DESCRIPTION
This commit introduces a new endpoint `/api/auth/me` that allows authenticated users (admin, agent, or student) to retrieve their profile details.

The implementation includes:
- A new controller function `getUserDetails` in `authController.ts` to handle the logic of fetching user profiles based on their role.
- Updates to `authRoutes.ts` to define the new GET `/me` route, protected by the authentication middleware.
- Swagger API documentation for the new endpoint, outlining request parameters and possible responses for different user roles.