### PR TITLE
Fix: Resolve Swagger schema reference errors

### DIFF
--- a/src/swagger/paths/auth.ts
+++ b/src/swagger/paths/auth.ts
@@ -58,9 +58,9 @@ export const authPaths: OpenAPIV3.PathsObject = {
             'application/json': {
               schema: {
                 oneOf: [
-                  { $ref: '#/components/schemas/AdminProfileResponse' },
-                  { $ref: '#/components/schemas/AgentProfileResponse' },
-                  { $ref: '#/components/schemas/UserResponse' },
+                  { $ref: '#/components/schemas/Admin' },
+                  { $ref: '#/components/schemas/Agent' },
+                  { $ref: '#/components/schemas/Student' },
                 ],
               },
             },

--- a/src/swagger/schemas/commonSchemas.ts
+++ b/src/swagger/schemas/commonSchemas.ts
@@ -1,0 +1,14 @@
+// File: src/swagger/schemas/commonSchemas.ts
+import { OpenAPIV3 } from 'openapi-types';
+
+export const commonSchemas: OpenAPIV3.ComponentsObject['schemas'] = {
+  ErrorResponse: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'An error occurred' },
+      statusCode: { type: 'integer', example: 400 },
+      error: { type: 'string', example: 'Bad Request' },
+    },
+    required: ['message', 'statusCode', 'error'],
+  },
+};

--- a/src/swagger/schemas/index.ts
+++ b/src/swagger/schemas/index.ts
@@ -14,6 +14,7 @@ import { adminUniversitySchemas } from './adminUniversitySchemas';
 import { searchSchemas } from './searchSchema';
 
 import { notificationSchemas } from './notificationSchemas';
+import { commonSchemas } from './commonSchemas';
 
 export const allSchemas = {
   // existing core schemas
@@ -35,4 +36,5 @@ export const allSchemas = {
 
   // notification schemas
   ...notificationSchemas,
+  ...commonSchemas,
 };


### PR DESCRIPTION
Corrected several $ref pointers in the Swagger/OpenAPI documentation that were causing resolver errors.

- Defined a new `ErrorResponse` schema in `src/swagger/schemas/commonSchemas.ts` and integrated it into the main schema list. This addresses missing `ErrorResponse` references.
- Updated `src/swagger/paths/auth.ts` for the `/api/auth/me` endpoint:
    - Changed `AdminProfileResponse` to `Admin`.
    - Changed `AgentProfileResponse` to `Agent`.
    - Changed `UserResponse` to `Student`.

These changes ensure that all schema references in the `/api/auth/me` path now point to valid, defined schemas within the API documentation.